### PR TITLE
Revert "Update xproc.rnc"

### DIFF
--- a/langspec/schemas/xproc.rnc
+++ b/langspec/schemas/xproc.rnc
@@ -182,7 +182,7 @@ InputConnection =
       common.attributes,
       inline.attributes,
       use-when.attr?,
-      (((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)|Any)
+      (((\Empty|(Document|Inline)+)? & (Documentation|PipeInfo)*)|Any)
    }
 
 [


### PR DESCRIPTION
Reverts xml-project/3.0-specification#3

xproc.rnc war wohl doch nicht das richtige Dokument. Ich probiere ich morgen noch mal mit rng