### PR TITLE
Attempt to fix Issue 70

### DIFF
--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -17,6 +17,9 @@
   <define name="ContentTypes" sa:model="ContentTypes">
     <text/>
   </define>
+  <define name="StringMap">
+    <text>map(xs:string, xs:string)</text>
+  </define>
   <define name="name.ncname.attr">
     <attribute name="name">
       <data type="NCName"/>
@@ -67,7 +70,7 @@
   </define>
   <define name="document-properties.attr">
     <attribute name="document-properties">
-      <data type="map(string,string)" />
+      <ref name="StringMap" />
     </attribute>
   </define>
   <define name="content-type.attr">

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -1299,8 +1299,8 @@
         </attribute>
       </optional>
       <optional>
-        <attribute name="document-properties">
-          <ref name="StringMap" />
+        <attribute name="override-content-type">
+         <data type="boolean"/>
         </attribute>
       </optional>
       <group>

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -1300,7 +1300,7 @@
       </optional>
       <optional>
         <attribute name="override-content-type">
-         <data type="boolean"/>
+         <ref name="ContentType"/>
         </attribute>
       </optional>
       <group>

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -455,9 +455,7 @@
     <element name="document">
       <ref name="href.attr"/>
       <optional>
-        <attribute name="document-properties">
-          <ref name="document-properties.attr"/>
-        </attribute>
+        <ref name="document-properties.attr"/>
       </optional>
       <ref name="common.attributes"/>
       <optional>

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -455,8 +455,8 @@
     <element name="document">
       <ref name="href.attr"/>
       <optional>
-        <attribute name="override-content-type">
-          <ref name="ContentType"/>
+        <attribute name="document-properties">
+          <ref name="document-properties.attr"/>
         </attribute>
       </optional>
       <ref name="common.attributes"/>

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -17,8 +17,8 @@
   <define name="ContentTypes" sa:model="ContentTypes">
     <text/>
   </define>
-  <define name="StringMap">
-    <text>map(xs:string, xs:string)</text>
+  <define name="StringMap" sa:model="map(xs:string, xs:string)">
+    <text />
   </define>
   <define name="name.ncname.attr">
     <attribute name="name">

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -1299,8 +1299,8 @@
         </attribute>
       </optional>
       <optional>
-        <attribute name="override-content-type">
-          <ref name="ContentType"/>
+        <attribute name="document-properties">
+          <ref name="StringMap" />
         </attribute>
       </optional>
       <group>

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -65,6 +65,10 @@
       <data type="boolean"/>
     </attribute>
   </define>
+  <define name="document-properties.attr">
+    <attribute name="document-properties">
+      <data type="map(string,string)" />
+  </define>
   <define name="content-type.attr">
     <attribute name="content-type">
       <ref name="ContentType"/>

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -68,6 +68,7 @@
   <define name="document-properties.attr">
     <attribute name="document-properties">
       <data type="map(string,string)" />
+    </attribute>
   </define>
   <define name="content-type.attr">
     <attribute name="content-type">
@@ -480,7 +481,7 @@
         </attribute>
       </optional>
       <optional>
-        <ref name="content-type.attr"/>
+        <ref name="document-properties.attr"/>
       </optional>
       <optional>
         <attribute name="encoding"/>

--- a/langspec/xproc30-steps/steps.xml
+++ b/langspec/xproc30-steps/steps.xml
@@ -1389,10 +1389,10 @@ the <tag>p:load</tag> step is equivalent to performing the following
 
 <para>Where the “<literal>{HREF}</literal>” value is the value of
 the <option>href</option> option made absolute and the
-“<literal>{OVERRIDE}</literal> value is the value of the
-<option>override-content-type</option> option. If no value is provided
-for the <option>override-content-type</option> option, then the
-<tag class="attribute">override-content-type</tag> attribute is not
+“<literal>{DOCUMENT-PROPERTIES}</literal> value is the value of the
+<option>document-properties</option> option. If no value is provided
+for the <option>document-properties</option> option, then the
+<tag class="attribute">document-properties</tag> attribute is not
 present on the <tag>c:request</tag>.</para>
 
 <para>If <option>dtd-validate</option> is <literal>true</literal>,

--- a/langspec/xproc30-steps/steps.xml
+++ b/langspec/xproc30-steps/steps.xml
@@ -1357,7 +1357,7 @@ result a document (or documents) specified by an IRI.</para>
   <p:output port="result" sequence="true"/>
   <p:option name="href" required="true" as="xs:anyURI"/>
   <p:option name="dtd-validate" select="'false'" as="xs:boolean"/>
-  <p:option name="override-content-type" as="xs:string"/>
+  <p:option name="document-properties" as="map(xs:string, xs:string)"/>
 </p:declare-step>
 
 <para>The value of the <option>href</option> option
@@ -1382,7 +1382,7 @@ the <tag>p:load</tag> step is equivalent to performing the following
                  href="{HREF}"
                  detailed="false"
                  status-only="false"
-                 override-content-type="{OVERRIDE}"/>
+                 document-properties="{DOCUMENT-PROPERTIES}"/>
     </p:inline>
   </p:input>
 </p:http-request>]]></programlisting>
@@ -1402,7 +1402,7 @@ pipeline:</para>
 <programlisting language="xml"><![CDATA[<p:declare-step>
   <p:output port="result" sequence="false"/>
   <p:option name="href" required="true"/>
-  <p:option name="override-content-type"/>
+  <p:option name="document-properties"/>
 
   <p:http-request>
     <p:input port="source">
@@ -1411,7 +1411,7 @@ pipeline:</para>
                    href="{$href}"
                    detailed="false"
                    status-only="false"
-                   override-content-type="text/plain"/>
+                   document-properties="map{"content-type":"text/plain"}"/>
       </p:inline>
     </p:input>
   </p:http-request>
@@ -1419,8 +1419,8 @@ pipeline:</para>
   <p:xml-parse dtd-validate="true"/>
 
   <p:choose>
-    <p:when test="p:value-availalle('override-content-type')">
-      <p:cast-content-type content-type="{$override-content-type}"/>
+    <p:when test="p:value-available('document-properties')">
+      <p:cast-content-type content-type="{map:get($document-properties,'content-type')}"/>
     </p:when>
     <p:otherwise>
       <p:identity/>

--- a/langspec/xproc30-steps/steps.xml
+++ b/langspec/xproc30-steps/steps.xml
@@ -1419,7 +1419,7 @@ pipeline:</para>
   <p:xml-parse dtd-validate="true"/>
 
   <p:choose>
-    <p:when test="p:value-available('document-properties')">
+    <p:when test="p:value-available('document-properties') and map:contains($document-properties,'content-type')">
       <p:cast-content-type content-type="{map:get($document-properties,'content-type')}"/>
     </p:when>
     <p:otherwise>

--- a/langspec/xproc30-steps/steps.xml
+++ b/langspec/xproc30-steps/steps.xml
@@ -1382,17 +1382,18 @@ the <tag>p:load</tag> step is equivalent to performing the following
                  href="{HREF}"
                  detailed="false"
                  status-only="false"
-                 document-properties="{DOCUMENT-PROPERTIES}"/>
+                 override-content-type="{OVERRIDE}"/>
     </p:inline>
   </p:input>
 </p:http-request>]]></programlisting>
 
 <para>Where the “<literal>{HREF}</literal>” value is the value of
 the <option>href</option> option made absolute and the
-“<literal>{DOCUMENT-PROPERTIES}</literal> value is the value of the
-<option>document-properties</option> option. If no value is provided
-for the <option>document-properties</option> option, then the
-<tag class="attribute">document-properties</tag> attribute is not
+“<literal>{OVERRIDE}</literal> value is the value returned by 
+<literal>map:get($document-properties,'content-type')</literal>. If no value is provided
+for the <option>document-properties</option> option or the provided map does not contain 
+a key 'content-type', then the
+<tag class="attribute">override-content-type</tag> attribute is not
 present on the <tag>c:request</tag>.</para>
 
 <para>If <option>dtd-validate</option> is <literal>true</literal>,
@@ -1411,7 +1412,7 @@ pipeline:</para>
                    href="{$href}"
                    detailed="false"
                    status-only="false"
-                   document-properties="map{"content-type":"text/plain"}"/>
+                   override-content-type="text/plain"/>
       </p:inline>
     </p:input>
   </p:http-request>

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -4404,11 +4404,14 @@ output of one of its children.</para>
 
 <e:rng-pattern name="Inline"/>
 
+<para>The <tag class="attribute">document-properties</tag> attribute can 
+  be used to set the document properties of the provided document. The document's 
+  content type is determined by the value of the "content-type" key in the provided map.
+  If no <tag class="attribute">document-properties</tag> is provided or the map does not
+  contain a "content-type" key, the value "<literal>application/xml</literal>" is assumed.
+</para>
 <para>How the content of a <tag>p:inline</tag> element is interpreted
-depends on the <tag class="attribute">content-type</tag> and
-<tag class="attribute">encoding</tag> attributes. If no
-<tag class="attribute">content-type</tag> is provided, the value
-“<literal>application/xml</literal>” is assumed.
+depends on the document's content type and the <tag class="attribute">encoding</tag> attribute.
 </para>
 
 <!--

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -4405,7 +4405,7 @@ output of one of its children.</para>
 <e:rng-pattern name="Inline"/>
 
 <para>The <tag class="attribute">document-properties</tag> attribute can 
-  be used to set the <firstterm>document properties</firstterm> of the provided document. The document's 
+  be used to set the <glossterm>document properties</glossterm> of the provided document. The document's 
   content type is determined by the value of the "content-type" key in the provided map.
   If no attribute <tag class="attribute">document-properties</tag> is provided or the provided map does not
   contain a "content-type" key, the value "<literal>application/xml</literal>" is assumed.

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -4643,8 +4643,8 @@ the base URI of the <tag>p:document</tag> element.</para>
 <para>The semantics of <tag>p:document</tag> are the same as a the
 semantics of <tag>p:load</tag> where the <option>href</option> option
 comes from the <tag class="attribute">href</tag> attribute, the
-<option>override-content-type</option> option comes from the
-<tag class="attribute">override-content-type</tag> attribute, and the
+<option>document-properties</option> option comes from the
+<tag class="attribute">document-properties</tag> attribute, and the
 <option>dtd-validate</option> option is always <literal>false</literal>.
 </para>
 

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -4405,9 +4405,9 @@ output of one of its children.</para>
 <e:rng-pattern name="Inline"/>
 
 <para>The <tag class="attribute">document-properties</tag> attribute can 
-  be used to set the document properties of the provided document. The document's 
+  be used to set the <firstterm>document properties</firstterm> of the provided document. The document's 
   content type is determined by the value of the "content-type" key in the provided map.
-  If no <tag class="attribute">document-properties</tag> is provided or the map does not
+  If no attribute <tag class="attribute">document-properties</tag> is provided or the provided map does not
   contain a "content-type" key, the value "<literal>application/xml</literal>" is assumed.
 </para>
 <para>How the content of a <tag>p:inline</tag> element is interpreted
@@ -4484,13 +4484,13 @@ class="attribute">encoding</tag> attribute.</error>
 </para>
 
 <para>The interpretation of the (possibily decoded) content
-depends on the <tag class="attribute">content-type</tag> attribute.
+depends on the document's content type.
 </para>
 
 <section xml:id="inline-non-xml">
 <title>Inline non-XML content</title>
 
-<para>If the <tag class="attribute">content-type</tag> is not
+<para>If the document's content type is not
 an <glossterm>XML media type</glossterm>, then the content is
 non-XML.</para>
 
@@ -4501,8 +4501,9 @@ non-XML.</para>
 <section xml:id="inline-xml-content">
 <title>Inline XML content</title>
 
-<para>If the <tag class="attribute">content-type</tag> is not
-specified or specifies an <glossterm>XML media type</glossterm>, then
+<para>If the <tag class="attribute">document-properties</tag> is not
+specified or the map does not contain a key "content-type" or specifies 
+an <glossterm>XML media type</glossterm>, then
 the content is XML. <error code="S0024">It is a <glossterm>static
 error</glossterm> if the content of the <tag>p:inline</tag> element
 does not consist of exactly one element, optionally preceded and/or


### PR DESCRIPTION
Trying to fix https://github.com/xproc/3.0-specification/issues/70 partially: Option "document-properties" is introduced on p:inline, p:document and p:load, but not on p:http-request.