### PR TITLE
Fixing match requirement in p:add-attribute

### DIFF
--- a/langspec/xproc30-steps/steps/add-attribute.xml
+++ b/langspec/xproc30-steps/steps/add-attribute.xml
@@ -29,8 +29,8 @@ with the specified value.
 
 <para>The value of the <option>match</option> option
 <rfc2119>must</rfc2119> be an XSLTMatchPattern. <error code="C0023">It
-is a <glossterm>dynamic error</glossterm> if the match pattern does
-not match an element.</error></para>
+is a <glossterm>dynamic error</glossterm> if the match pattern matches a node
+which is not an element.</error></para>
 
 <para>The value of the <option>attribute-name</option> option
 <rfc2119>must</rfc2119> be a <type>QName</type>.


### PR DESCRIPTION
I do not think, that is is necessary for p:add-attribute to match anything, but if it does, it needs to be an element.